### PR TITLE
fix: GitHub Pages deployment with correct base path

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../../packages/config" },
     { "path": "../../packages/core" },
     { "path": "../../packages/state" },
+    { "path": "../../packages/audio" },
     { "path": "../../packages/rendering" },
     { "path": "../../packages/ui" }
   ]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Base path for GitHub Pages deployment at /otter-river-rush/
+  base: '/otter-river-rush/',
   server: {
     port: 3000,
   },

--- a/packages/audio/src/audio-manager.ts
+++ b/packages/audio/src/audio-manager.ts
@@ -5,24 +5,27 @@
 
 import { Sound, Scene, Engine } from '@babylonjs/core';
 
+// Use Vite's base URL for GitHub Pages subdirectory deployment
+const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
+
 // Audio asset paths
 export const AUDIO_PATHS = {
   music: {
-    gameplay: '/assets/audio/music/flowing-rocks.ogg',
-    ambient: '/assets/audio/music/night-at-beach.ogg',
-    gameOver: '/assets/audio/music/game-over.ogg',
+    gameplay: `${BASE_URL}/audio/music/flowing-rocks.ogg`,
+    ambient: `${BASE_URL}/audio/music/night-at-beach.ogg`,
+    gameOver: `${BASE_URL}/audio/music/game-over.ogg`,
   },
   sfx: {
-    coinPickup: '/assets/audio/sfx/coin-pickup.ogg',
-    gemPickup: '/assets/audio/sfx/gem-pickup.ogg',
-    bonus: '/assets/audio/sfx/bonus.ogg',
-    hit: '/assets/audio/sfx/hit.ogg',
-    click: '/assets/audio/sfx/click.ogg',
-    confirm: '/assets/audio/sfx/confirm.ogg',
+    coinPickup: `${BASE_URL}/audio/sfx/coin-pickup.ogg`,
+    gemPickup: `${BASE_URL}/audio/sfx/gem-pickup.ogg`,
+    bonus: `${BASE_URL}/audio/sfx/bonus.ogg`,
+    hit: `${BASE_URL}/audio/sfx/hit.ogg`,
+    click: `${BASE_URL}/audio/sfx/click.ogg`,
+    confirm: `${BASE_URL}/audio/sfx/confirm.ogg`,
   },
   ambient: {
-    waterDrip1: '/assets/audio/ambient/water-drip1.ogg',
-    waterDrip2: '/assets/audio/ambient/water-drip2.ogg',
+    waterDrip1: `${BASE_URL}/audio/ambient/water-drip1.ogg`,
+    waterDrip2: `${BASE_URL}/audio/ambient/water-drip2.ogg`,
   },
 } as const;
 

--- a/packages/audio/src/vite-env.d.ts
+++ b/packages/audio/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/audio/tsconfig.json
+++ b/packages/audio/tsconfig.json
@@ -9,7 +9,9 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "composite": true,
+    "rootDir": "src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/config/src/characters.ts
+++ b/packages/config/src/characters.ts
@@ -7,6 +7,9 @@
  * - Special abilities
  */
 
+// Use Vite's base URL for GitHub Pages subdirectory deployment
+const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
+
 export interface OtterCharacter {
   id: string;
   name: string;
@@ -53,8 +56,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A cheerful brown otter who loves splashing through rivers. Reliable and steady, Rusty is perfect for beginners.',
     personality: 'Friendly, determined, always optimistic',
-    modelPath: '/assets/models/player/otter-player/model.glb',
-    thumbnailPath: '/assets/models/player/otter-player/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-player/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-player/thumbnail.png`,
 
     theme: {
       primaryColor: '#8B4513', // Saddle brown
@@ -84,8 +87,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A sleek silver otter who moves like moonlight on water. Quick reflexes make dodging a breeze.',
     personality: 'Wise, calm, mysterious night owl',
-    modelPath: '/assets/models/player/otter-silver/model.glb',
-    thumbnailPath: '/assets/models/player/otter-silver/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-silver/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-silver/thumbnail.png`,
 
     theme: {
       primaryColor: '#708090', // Slate gray
@@ -117,8 +120,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A magnificent golden otter with a nose for treasure. Everything Goldie touches turns to riches!',
     personality: 'Regal, lucky, loves shiny things',
-    modelPath: '/assets/models/player/otter-golden/model.glb',
-    thumbnailPath: '/assets/models/player/otter-golden/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-golden/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-golden/thumbnail.png`,
 
     theme: {
       primaryColor: '#DAA520', // Goldenrod
@@ -150,8 +153,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A fluffy white otter from the frozen north. Frost thrives on speed and challenge!',
     personality: 'Playful, adventurous, loves a challenge',
-    modelPath: '/assets/models/player/otter-arctic/model.glb',
-    thumbnailPath: '/assets/models/player/otter-arctic/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-arctic/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-arctic/thumbnail.png`,
 
     theme: {
       primaryColor: '#F0F8FF', // Alice blue

--- a/packages/config/src/vite-env.d.ts
+++ b/packages/config/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/game-core/src/assets/AssetBridge.web.ts
+++ b/packages/game-core/src/assets/AssetBridge.web.ts
@@ -16,7 +16,9 @@ import {
   getDecorationVariants,
 } from './AssetRegistry';
 
-const BASE_URL = '/assets';
+// Use Vite's base URL for GitHub Pages subdirectory deployment
+// import.meta.env.BASE_URL is '/otter-river-rush/' in production, '/' in dev
+const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
 
 /**
  * Resolve an asset definition to a full URL

--- a/packages/game-core/src/config/characters.ts
+++ b/packages/game-core/src/config/characters.ts
@@ -7,6 +7,9 @@
  * - Special abilities
  */
 
+// Use Vite's base URL for GitHub Pages subdirectory deployment
+const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
+
 export interface OtterCharacter {
   id: string;
   name: string;
@@ -53,8 +56,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A cheerful brown otter who loves splashing through rivers. Reliable and steady, Rusty is perfect for beginners.',
     personality: 'Friendly, determined, always optimistic',
-    modelPath: '/assets/models/player/otter-player/model.glb',
-    thumbnailPath: '/assets/models/player/otter-player/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-player/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-player/thumbnail.png`,
 
     theme: {
       primaryColor: '#8B4513', // Saddle brown
@@ -84,8 +87,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A sleek silver otter who moves like moonlight on water. Quick reflexes make dodging a breeze.',
     personality: 'Wise, calm, mysterious night owl',
-    modelPath: '/assets/models/player/otter-silver/model.glb',
-    thumbnailPath: '/assets/models/player/otter-silver/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-silver/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-silver/thumbnail.png`,
 
     theme: {
       primaryColor: '#708090', // Slate gray
@@ -117,8 +120,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A magnificent golden otter with a nose for treasure. Everything Goldie touches turns to riches!',
     personality: 'Regal, lucky, loves shiny things',
-    modelPath: '/assets/models/player/otter-golden/model.glb',
-    thumbnailPath: '/assets/models/player/otter-golden/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-golden/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-golden/thumbnail.png`,
 
     theme: {
       primaryColor: '#DAA520', // Goldenrod
@@ -150,8 +153,8 @@ export const OTTER_CHARACTERS: OtterCharacter[] = [
     description:
       'A fluffy white otter from the frozen north. Frost thrives on speed and challenge!',
     personality: 'Playful, adventurous, loves a challenge',
-    modelPath: '/assets/models/player/otter-arctic/model.glb',
-    thumbnailPath: '/assets/models/player/otter-arctic/thumbnail.png',
+    modelPath: `${BASE_URL}/models/player/otter-arctic/model.glb`,
+    thumbnailPath: `${BASE_URL}/models/player/otter-arctic/thumbnail.png`,
 
     theme: {
       primaryColor: '#F0F8FF', // Alice blue

--- a/packages/game-core/src/vite-env.d.ts
+++ b/packages/game-core/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/rendering/src/components/EntityRenderer.tsx
+++ b/packages/rendering/src/components/EntityRenderer.tsx
@@ -17,8 +17,9 @@ interface LoadedModel {
   entity: Entity;
 }
 
-// Default otter model (fallback)
-const DEFAULT_OTTER_MODEL = '/assets/models/player/otter-player/model.glb';
+// Default otter model (fallback) - uses Vite's base URL for GitHub Pages
+const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
+const DEFAULT_OTTER_MODEL = `${BASE_URL}/models/player/otter-player/model.glb`;
 
 export function EntityRenderer() {
   const scene = useScene();

--- a/packages/rendering/src/vite-env.d.ts
+++ b/packages/rendering/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Set Vite base path to `/otter-river-rush/` for subdirectory deployment
- Use `import.meta.env.BASE_URL` for dynamic asset path resolution in all packages
- Add vite-env.d.ts for TypeScript Vite client type support
- Update tsconfig references for proper project build

## Problem
GitHub Pages was showing only a blue screen because:
1. The Vite build didn't have a base path configured
2. Asset paths were hardcoded to `/assets/...` instead of `/otter-river-rush/assets/...`

## Test plan
- [ ] Verify build succeeds: `pnpm build`
- [ ] Verify GitHub Pages deployment loads the game at https://arcade-cabinet.github.io/otter-river-rush/
- [ ] Verify assets (models, audio) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for GitHub Pages compatibility with a custom base path.
  * Improved asset path resolution to dynamically adapt to the deployment environment, replacing static paths with environment-aware path construction for models, audio, and other resources.
  * Enhanced TypeScript configuration for better build orchestration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->