### PR TITLE
fix: add game-core reference to types package tsconfig

### DIFF
--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -8,5 +8,8 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../game-core" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add TypeScript project reference from types package to game-core package
- Fixes build order issue where types package couldn't find game-core exports

## Test plan
- [ ] Verify `pnpm type-check` passes
- [ ] Verify CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve project structure and enable composite builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->