### PR TITLE
fix: use tsc --build for audio package typecheck

### DIFF
--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --build --force"
   },
   "dependencies": {
     "@babylonjs/core": "^8.46.2"

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -8,5 +8,8 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../game-core" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Change audio package typecheck to use `tsc --build --force` instead of `tsc --noEmit`
- Fixes CI failure where web app couldn't find audio's .d.ts files

## Test plan
- [ ] Verify `pnpm type-check` passes
- [ ] Verify CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)