### PR TITLE
Fix web deployment failure on Render due to incorrect base path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build web bundle
         uses: ./.github/actions/build-web
+        env:
+          VITE_BASE_URL: /otter-river-rush/
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,18 +1,21 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  // Base path for GitHub Pages deployment at /otter-river-rush/
-  base: '/otter-river-rush/',
-  server: {
-    port: 3000,
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-  },
-  optimizeDeps: {
-    include: ['@babylonjs/core', '@babylonjs/loaders', 'reactylon'],
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    // Base path for deployment (Render uses /, GitHub Pages uses /otter-river-rush/)
+    base: env.VITE_BASE_URL || '/otter-river-rush/',
+    server: {
+      port: 3000,
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: true,
+    },
+    optimizeDeps: {
+      include: ['@babylonjs/core', '@babylonjs/loaders', 'reactylon'],
+    },
+  };
 });

--- a/packages/rendering/src/components/EntityRenderer.tsx
+++ b/packages/rendering/src/components/EntityRenderer.tsx
@@ -18,7 +18,10 @@ interface LoadedModel {
 }
 
 // Default otter model (fallback) - uses Vite's base URL for GitHub Pages
-const BASE_URL = `${import.meta.env.BASE_URL ?? '/'}assets`;
+// Handle potential double slash if BASE_URL has trailing slash
+const rawBase = import.meta.env.BASE_URL ?? '/';
+const normalizedBase = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
+const BASE_URL = `${normalizedBase}assets`;
 const DEFAULT_OTTER_MODEL = `${BASE_URL}/models/player/otter-player/model.glb`;
 
 export function EntityRenderer() {

--- a/render.yaml
+++ b/render.yaml
@@ -84,6 +84,7 @@ services:
         value: 22.0.0
       - key: VITE_APP_VERSION
         sync: false # Set in Render Dashboard
+      # Crucial: Set base URL to root for Render deployment (overrides default /otter-river-rush/)
       - key: VITE_BASE_URL
         value: /
 


### PR DESCRIPTION
Updated `apps/web/vite.config.ts` to use `loadEnv` and set `base` property dynamically based on `VITE_BASE_URL`. This fixes the "blue screen" issue on Render where assets were failing to load due to incorrect base path. Default behavior for GitHub Pages is preserved.

---
*PR created automatically by Jules for task [10380251972409526067](https://jules.google.com/task/10380251972409526067) started by @jbdevprimary*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build configuration now adapts at build time to pick the correct base URL for different hosting targets.
* **Bug Fixes**
  * Prevents broken asset links by normalizing base paths to avoid duplicate slashes.
* **Chores**
  * CI/build step now passes the base URL into the web build for consistent outputs.
* **Documentation**
  * Deployment config comment clarifies when to override the base URL for specific hosts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->